### PR TITLE
let all packages depend on the aptget_update command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -264,6 +264,10 @@ class apt (
     refreshonly => true,
   }
 
+  Package <| title != $apt::package |> {
+    require +> Exec['aptget_update']
+  }
+
   ### Include custom class if $my_class is set
   if $apt::my_class {
     include $apt::my_class


### PR DESCRIPTION
This one is quite aggressive, but it ensures that changes to the apt config are applied immediately, which is a hard requirement when bootstrapping something.
