### PR TITLE
Update unattended-upgrades.Ubuntu.erb

### DIFF
--- a/templates/unattended-upgrades.Ubuntu.erb
+++ b/templates/unattended-upgrades.Ubuntu.erb
@@ -1,6 +1,6 @@
 Unattended-Upgrade::Allowed-Origins {
-        "Ubuntu <%= lsbdistcodename %>-security";
-        //"Ubuntu <%= lsbdistcodename %>-updates";
+        "Ubuntu <%= @lsbdistcodename %>-security";
+        //"Ubuntu <%= @lsbdistcodename %>-updates";
 };
 Unattended-Upgrade::Package-Blacklist {
 //  "vim";
@@ -15,8 +15,8 @@ Unattended-Upgrade::Package-Blacklist {
 // must be installed or anything that provides /usr/bin/mail.
 //Unattended-Upgrade::Mail "root@localhost";
 
-<% if mail != "" -%>
-Unattended-Upgrade::Mail "<%= mail %>";
+<% if @mail != "" -%>
+Unattended-Upgrade::Mail "<%= @mail %>";
 <% end -%>
 
 


### PR DESCRIPTION
```
Warning: Variable access via 'lsbdistcodename' is deprecated. Use '@lsbdistcodename' instead. template[modules/apt/templates/unattended-upgrades.Ubuntu.erb]:2
(at modules/apt/templates/unattended-upgrades.Ubuntu.erb:2:in `result')
Warning: Variable access via 'lsbdistcodename' is deprecated. Use '@lsbdistcodename' instead. template[modules/apt/templates/unattended-upgrades.Ubuntu.erb]:3
(at modules/apt/templates/unattended-upgrades.Ubuntu.erb:3:in `result')
Warning: Variable access via 'mail' is deprecated. Use '@mail' instead. template[modules/apt/templates/unattended-upgrades.Ubuntu.erb]:18
(at modules/apt/templates/unattended-upgrades.Ubuntu.erb:18:in `result')
Warning: Variable access via 'mail' is deprecated. Use '@mail' instead. template[modules/apt/templates/unattended-upgrades.Ubuntu.erb]:19
(at modules/apt/templates/unattended-upgrades.Ubuntu.erb:19:in `result')
```
