### PR TITLE
added dotdeb repo

### DIFF
--- a/manifests/repo/dotdeb.pp
+++ b/manifests/repo/dotdeb.pp
@@ -1,0 +1,19 @@
+# = Class: apt::repo::dotdeb
+#
+# This class installs the dotdeb repo
+#
+class apt::repo::dotdeb {
+
+  case $::operatingsystem {
+  Debian: {
+    apt::repository { 'dotdeb':
+      url        => 'http://packages.dotdeb.org/',
+      distro     => $::lsbdistcodename,
+      repository => 'all',
+      key        => '89DF5277',
+    }
+  }
+  default: {}
+  }
+
+}


### PR DESCRIPTION
Dotdeb is a repository containing packages to turn your Debian boxes into powerful, stable and up-to-date LAMP servers:

Nginx,
PHP 5.4 and 5.3,
useful PHP extensions : APC, imagick, Pinba, xcache, Xdebug, XHprof…
MySQL 5.5,
Percona toolkit,
Redis,
Zabbix,
Passenger...
