### PR TITLE
Allow to pass keyserver argument to repository

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -24,6 +24,9 @@
 # [*key*]
 #   Fingerprint of the key to retrieve
 #
+# [*keyserver*]
+#   Keyserver to use
+#
 # [*key_url*]
 #   Url from which fetch the key
 #
@@ -79,6 +82,7 @@ define apt::repository (
   $src_repo    = false,
   $key         = '',
   $key_url     = '',
+  $keyserver   = 'subkeys.pgp.net',
   $template    = '',
   $source      = '',
   $environment = undef,
@@ -119,6 +123,7 @@ define apt::repository (
     apt::key { $key:
       url         => $key_url,
       environment => $environment,
+      keyserver   => $keyserver,
       path        => $path,
       fingerprint => $key,
       notify      => Exec['aptget_update'],


### PR DESCRIPTION
This seems to be enough.  I noticed a slight inconsistency, there is keyserver in apt::repository and key_server in apt::source though. I picked keyserver as this is what is used in apt::key.
