### PR TITLE
Refactoring of unattended-upgrades

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -21,6 +21,10 @@
 # [*ensure*]
 #   Whether to add or delete this configuration
 #
+# [*suffix*]
+#   Prefix of the file generated.
+#   Default: .conf
+#
 #
 # == Examples
 #
@@ -35,7 +39,8 @@ define apt::conf (
   $source    = '' ,
   $content   = '' ,
   $priority  = '10' ,
-  $ensure    = present ) {
+  $ensure    = present,
+  $suffix    = '.conf', ) {
 
   include apt
 
@@ -51,7 +56,7 @@ define apt::conf (
 
   file { "apt_conf_${name}":
     ensure  => $ensure,
-    path    => "${apt::aptconfd_dir}/${priority}${name}.conf",
+    path    => "${apt::aptconfd_dir}/${priority}${name}${suffix}",
     mode    => $apt::config_file_mode,
     owner   => $apt::config_file_owner,
     group   => $apt::config_file_group,

--- a/manifests/unattended_upgrade_automatic.pp
+++ b/manifests/unattended_upgrade_automatic.pp
@@ -7,13 +7,16 @@
 #
 # [*mail*]
 #   E-mail address to which send reports, default don't send emails.
+#
 # [*mailonlyerror*]
 #   Set this value to "true" to get emails only on errors. Default
 #   is to always send a mail if mail is set.
+#
 # [*repository*]
 #   Array of extra repository to be added for unattended-upgreades,
 #   each line will be reported on the unattended-upgrades conf file example:
 #   origin=Puppetlabs,archive=wheezy,label=Puppetlabs
+#
 # [*blacklist*]
 #   Array of packages that you don't want to automatically update
 #   each line must contain the name of a package example:
@@ -21,11 +24,16 @@
 #     - vim
 #     - mysql-server
 #     - tomcat
+#
 # [*automaticreboot*]
 #   Boolean, default if not set is false, if set to true the system
 #   will reboot if necessarry at automatictime
+#
 # [*automatictime*]
 #   You can set the time of the reboot, default it's 02:00
+#
+# [*unattendedfilesuffix*]
+#   Suffix to be used for the unattended file name, default .conf
 #
 # == Examples
 #
@@ -34,12 +42,13 @@
 #
 #
 define apt::unattended_upgrade_automatic(
-  $mail            = '',
-  $mailonlyerror   = '',
-  $repository      = '',
-  $blacklist       = '',
-  $automaticreboot = '',
-  $automatictime   = '',
+  $mail                 = '',
+  $mailonlyerror        = '',
+  $repository           = [],
+  $blacklist            = [],
+  $automaticreboot      = '',
+  $automatictime        = '',
+  $unattendedfilesuffix = '.conf',
 
 ) {
 
@@ -59,17 +68,11 @@ define apt::unattended_upgrade_automatic(
 
   case $::lsbdistid {
     'Debian','Ubuntu': {
-      file { '50unattended-upgrades':
-        ensure  => file,
-        path    => "${apt::aptconfd_dir}/50unattended-upgrades",
-        content => template("apt/unattended-upgrades.${::lsbdistid}.erb"),
-        mode    => $apt::config_file_mode,
-        owner   => $apt::config_file_owner,
-        group   => $apt::config_file_group,
-        require => Package[$apt::package],
-        before  => Exec['aptget_update'],
-        notify  => Exec['aptget_update'],
-        audit   => $apt::manage_audit,
+        apt::conf { 'unattended-upgrades':
+          ensure   => present,
+          content  => template("apt/unattended-upgrades.${::lsbdistid}.erb"),
+          priority => '50',
+          suffix   => "$unattendedfilesuffix",
       }
     }
     default: {}

--- a/templates/unattended-upgrades.Debian.erb
+++ b/templates/unattended-upgrades.Debian.erb
@@ -1,4 +1,4 @@
-// File Managed By puppet
+// File Managed by Puppet
 // Unattended-Upgrade::Origins-Pattern controls which packages are
 // upgraded.
 //
@@ -21,54 +21,42 @@
 // derived from /etc/debian_version:
 //   ${distro_id}            Installed origin.
 //   ${distro_codename}      Installed codename (eg, "jessie")
-<% if @lsbdistcodename != 'squeeze' -%>
-Unattended-Upgrade::Origins-Pattern {
-        // Codename based matching:
-        // This will follow the migration of a release through different
-        // archives (e.g. from testing to stable and later oldstable).
-//      "o=Debian,n=jessie";
-//      "o=Debian,n=jessie-updates";
-//      "o=Debian,n=jessie-proposed-updates";
-//      "o=Debian,n=jessie,l=Debian-Security";
-
-        // Archive or Suite based matching:
-        // Note that this will silently match a different release after
-        // migration to the specified archive (e.g. testing becomes the
-        // new stable).
-      "o=Debian,a=stable";
-      "o=Debian,a=stable-updates";
-      "origin=Debian,archive=stable,label=Debian-Security";
-//      "o=Debian,a=proposed-updates";
-
-  <%- if @repository != "" -%>
-    <%- if @repository.is_a? Array -%>
-      <%- @repository.each do |singlerepo| -%>
-      "<%= singlerepo %>";
-      <%- end -%>
-    <%- else -%>
-      "<%= @repository %>";
-    <%- end -%>
-  <%- end -%>
-};
-<% else -%>
+<% if @lsbdistcodename == 'squeeze' -%>
 // unattended-upgrades (<< 0.70) doesn't support Origins-Pattern
 Unattended-Upgrade::Allowed-Origins {
-  "Debian <%= @lsbdistcodename %>";
-  "Debian <%= @lsbdistcodename %>-security";
+  "Debian oldstable";
+  "Debian oldstable-updates";
+  "Debian squeeze-lts";
+  <%- [@repository].flatten.each do |singlerepo| -%>
+  "<%= singlerepo %>";
+  <%- end -%>
+};
+<% elsif @lsbdistcodename == 'wheezy' -%>
+// unattended-upgrades (<< 0.80~exp2) doesn't support  codename
+Unattended-Upgrade::Origins-Pattern {
+        "origin=Debian,archive=stable,label=Debian";
+        "origin=Debian,archive=stable,label=Debian-Security";
+        "origin=Debian,archive=stable-updates,label=Debian";
+        <%- [@repository].flatten.each do |singlerepo| -%>
+        "<%= singlerepo %>";
+        <%- end -%>
+        
+};
+<% else -%>
+Unattended-Upgrade::Origins-Pattern {
+        "origin=Debian,codename=<%= @lsbdistcodename %>,label=Debian";
+        "origin=Debian,codename=<%= @lsbdistcodename %>,label=Debian-Security";
+        "origin=Debian,codename=<%= @lsbdistcodename %>-updates,label=Debian";
+        <%- [@repository].flatten.each do |singlerepo| -%>
+        "<%= singlerepo %>";
+        <%- end -%>
 };
 <% end -%>
-
 // List of packages to not update (regexp are supported)
 Unattended-Upgrade::Package-Blacklist {
-  <%- if @blacklist != "" -%>
-    <%- if @blacklist.is_a? Array -%>
-      <%- @blacklist.each do |singlepackage| -%>
- "<%= singlepackage %>";
-      <%- end -%>
-    <%- else -%>
- "<%= @blacklist %>";
-    <%- end -%>
-  <%- end -%>
+<%- [@blacklist].flatten.each do |singlepackage| -%>
+  "<%= singlepackage %>";
+<%- end -%>
 //	"vim";
 //	"libc6";
 //	"libc6-dev";
@@ -121,6 +109,7 @@ Unattended-Upgrade::Automatic-Reboot "<%= @automaticreboot %>";
 <% else -%>
 //Unattended-Upgrade::Automatic-Reboot "false";
 <% end -%>
+
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
 //  Default: "now"
@@ -129,6 +118,7 @@ Unattended-Upgrade::Automatic-Reboot-Time "<%= @automatictime %>";
 <% else -%>
 //Unattended-Upgrade::Automatic-Reboot-Time "02:00";
 <% end -%>
+
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";

--- a/templates/unattended-upgrades.Ubuntu.erb
+++ b/templates/unattended-upgrades.Ubuntu.erb
@@ -1,29 +1,19 @@
 // file managed by puppet
 Unattended-Upgrade::Allowed-Origins {
   "Ubuntu <%= @lsbdistcodename %>-security";
-   <%- if @repository != "" -%>
-    <%- if @repository.is_a? Array -%>
-      <%- @repository.each do |singlerepo| -%>
-      "<%= singlerepo %>";
-      <%- end -%>
-    <%- else -%>
-      "<%= @repository %>";
-    <%- end -%>
-  <%- end -%> 
+  <%- [@repository].flatten.each do |singlerepo| -%>
+  "<%= singlerepo %>";
+  <%- end -%>
+
   //"Ubuntu <%= @lsbdistcodename %>-updates";
 };
 
 // List of packages to not update (regexp are supported)
 Unattended-Upgrade::Package-Blacklist {
-  <%- if @blacklist != "" -%>
-    <%- if @blacklist.is_a? Array -%>
-      <%- @blacklist.each do |singlepackage| -%>
- "<%= singlepackage %>";
-      <%- end -%>
-    <%- else -%>
- "<%= @blacklist %>";
-    <%- end -%>
-  <%- end -%>
+<%- [@blacklist].flatten.each do |singlepackage| -%>
+  "<%= singlepackage %>";
+<%- end -%>
+
 //	"vim";
 //	"libc6";
 //	"libc6-dev";


### PR DESCRIPTION
Refactory of the unattended-upgrade function for apt.
Added many options that can be useful when selection new repository from which do autoupdate, put packages in blacklist and do automatic reboot.

Changed also the creation of the file 50unattended-upgrades, it was previously created with the apt::conf define that generate files with .conf extension, so after the installation of the package the directory would end up with 2 configuration files

50unattended-upgrades
50unattended-upgrades.conf

This can cause some confusion and unwanted behaviours.
