### PR TITLE
Added the option to specify a suffix for pin files

### DIFF
--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -68,6 +68,9 @@
 # [*ensure*]
 #   Whether to add or delete this pin
 #
+# [*file_suffix*]
+#   Suffix of the prefs file created, on some distribution it must be .pref
+#
 #
 # == Examples
 #
@@ -119,15 +122,16 @@
 #   }
 #
 define apt::pin (
-  $package  = '',
-  $type     = '',
-  $value    = '',
-  $priority = '',
-  $template = '',
-  $version  = '',
-  $release  = '',
-  $origin   = '',
-  $ensure   = 'present'
+  $package     = '',
+  $type        = '',
+  $value       = '',
+  $priority    = '',
+  $template    = '',
+  $version     = '',
+  $release     = '',
+  $origin      = '',
+  $ensure      = 'present',
+  $file_suffix = ''
 ) {
 
   include apt
@@ -175,7 +179,7 @@ define apt::pin (
 
   file { "apt_pin_${name}":
     ensure  => $ensure,
-    path    => "${apt::preferences_dir}/pin-${name}-${real_type}",
+    path    => "${apt::preferences_dir}/pin-${name}-${real_type}${file_suffix}",
     mode    => $apt::config_file_mode,
     owner   => $apt::config_file_owner,
     group   => $apt::config_file_group,


### PR DESCRIPTION
Hello,

While using this manifest on Debian 7 I got an error like:

 N: Ignoring file 'pin-libservlet3.0-java-release' in directory '/etc/apt/preferences.d/' as it has an invalid filename extension

This is easily solved if the file  has extension .pref and for what I've read around this depends on the apt version you are using.

So I've added an option (that is compatible with the past) to add an extension.

Best regards


