### PR TITLE
added new parameter to specify a keyserver

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,7 +191,8 @@ class apt (
   $config_dir_mode      = params_lookup( 'config_dir_mode' ),
   $config_file_mode     = params_lookup( 'config_file_mode' ),
   $config_file_owner    = params_lookup( 'config_file_owner' ),
-  $config_file_group    = params_lookup( 'config_file_group' )
+  $config_file_group    = params_lookup( 'config_file_group' ),
+  $keyserver            = params_lookup( 'keyserver' )
   ) inherits apt::params {
 
   ### Definition of some variables used in the module

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -37,9 +37,16 @@ define apt::key (
   $url             = '',
   $environment     = undef,
   $path            = '/usr/sbin:/usr/bin:/sbin:/bin',
-  $keyserver       = 'subkeys.pgp.net',
+  $keyserver       = '',
   $fingerprint     = ''
 ) {
+
+  include apt
+
+  $real_keyserver = $keyserver ? {
+    ''      => $apt::keyserver,
+    default => $keyserver,
+  }
 
   if $url != '' {
     exec { "aptkey_add_${name}":
@@ -50,7 +57,7 @@ define apt::key (
     }
   } else {
     exec { "aptkey_adv_${name}":
-      command     => "apt-key adv --keyserver ${keyserver} --recv ${fingerprint}",
+      command     => "apt-key adv --keyserver ${real_keyserver} --recv ${fingerprint}",
       unless      => "apt-key list | grep -q ${name}",
       environment => $environment,
       path        => $path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,5 +47,6 @@ class apt::params  {
 
   ### General module variables that can have a site or per module default
   $audit_only = false
+  $keyserver = 'subkeys.pgp.net'
 
 }

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -82,7 +82,7 @@ define apt::repository (
   $src_repo        = false,
   $key             = '',
   $key_url         = '',
-  $keyserver       = 'subkeys.pgp.net',
+  $keyserver       = '',
   $template        = '',
   $source          = '',
   $environment     = undef,
@@ -93,6 +93,10 @@ define apt::repository (
   ) {
   include apt
 
+  $real_keyserver = $keyserver ? {
+    ''      => $apt::keyserver,
+    default => $keyserver,
+  }
   $manage_file_source = $source ? {
     ''        => undef,
     default   => $source,
@@ -123,7 +127,7 @@ define apt::repository (
     apt::key { $key:
       url         => $key_url,
       environment => $environment,
-      keyserver   => $keyserver,
+      keyserver   => $real_keyserver,
       path        => $path,
       fingerprint => $key,
       notify      => Exec['aptget_update'],


### PR DESCRIPTION
Added a parameter to change keyserver.
"subkeys.pgp.net" is setup as default to maintain backward compatibility