### PR TITLE
Fixed exec unless parameter to match key fingerprint

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -51,14 +51,14 @@ define apt::key (
   if $url != '' {
     exec { "aptkey_add_${name}":
       command     => "wget -O - ${url} | apt-key add -",
-      unless      => "apt-key list | grep -q ${name}",
+      unless      => "apt-key adv --list-public-keys --with-fingerprint --with-colons | grep -q ${name}",
       environment => $environment,
       path        => $path,
     }
   } else {
     exec { "aptkey_adv_${name}":
       command     => "apt-key adv --keyserver ${real_keyserver} --recv ${fingerprint}",
-      unless      => "apt-key list | grep -q ${name}",
+      unless      => "apt-key adv --list-public-keys --with-fingerprint --with-colons | grep -q ${name}",
       environment => $environment,
       path        => $path,
     }

--- a/spec/defines/apt_key_spec.rb
+++ b/spec/defines/apt_key_spec.rb
@@ -13,7 +13,7 @@ describe 'apt::key' do
   describe 'Test apt key by name' do
     it 'should execute an adv command' do
       should contain_exec('aptkey_adv_sample1').with_command('apt-key adv --keyserver subkeys.pgp.net --recv print1')
-      should contain_exec('aptkey_adv_sample1').with_unless('apt-key list | grep -q sample1')
+      should contain_exec('aptkey_adv_sample1').with_unless('apt-key adv --list-public-keys --with-fingerprint --with-colons | grep -q sample1')
     end
   end
 
@@ -27,7 +27,7 @@ describe 'apt::key' do
 
     it 'should execute an adv command' do
       should contain_exec('aptkey_adv_sample2').with_command('apt-key adv --keyserver server2 --recv print2')
-      should contain_exec('aptkey_adv_sample2').with_unless('apt-key list | grep -q sample2')
+      should contain_exec('aptkey_adv_sample2').with_unless('apt-key adv --list-public-keys --with-fingerprint --with-colons | grep -q sample2')
     end
   end
 
@@ -40,7 +40,7 @@ describe 'apt::key' do
 
     it 'should execute a wget command' do
       should contain_exec('aptkey_add_sample3').with_command('wget -O - url3 | apt-key add -')
-      should contain_exec('aptkey_add_sample3').with_unless('apt-key list | grep -q sample3')
+      should contain_exec('aptkey_add_sample3').with_unless('apt-key adv --list-public-keys --with-fingerprint --with-colons | grep -q sample3')
     end
   end
 

--- a/spec/defines/apt_repository_spec.rb
+++ b/spec/defines/apt_repository_spec.rb
@@ -151,7 +151,7 @@ deb url4 distro4 repo4/)
     end
     it 'should execute an adv command' do
       should contain_exec('aptkey_adv_key4').with_command('apt-key adv --keyserver subkeys.pgp.net --recv key4')
-      should contain_exec('aptkey_adv_key4').with_unless('apt-key list | grep -q key4')
+      should contain_exec('aptkey_adv_key4').with_unless('apt-key adv --list-public-keys --with-fingerprint --with-colons | grep -q key4')
     end
   end
 
@@ -181,7 +181,7 @@ deb url5 distro5 repo5/)
     end
     it 'should execute a wget command' do
       should contain_exec('aptkey_add_key5').with_command('wget -O - key5_url | apt-key add -')
-      should contain_exec('aptkey_add_key5').with_unless('apt-key list | grep -q key5')
+      should contain_exec('aptkey_add_key5').with_unless('apt-key adv --list-public-keys --with-fingerprint --with-colons | grep -q key5')
     end
   end
 


### PR DESCRIPTION
grep command in the unless parameter never matches the fingerprint and apt::key always runs the exec.

apt-key list | grep -q 150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6
echo $?
1

apt-key adv --list-public-keys --with-fingerprint --with-colons | grep -q 150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6
echo $?
0