### PR TITLE
Stop double-quoting Mesosphere repo URL

### DIFF
--- a/manifests/repo/mesosphere.pp
+++ b/manifests/repo/mesosphere.pp
@@ -14,7 +14,7 @@ class apt::repo::mesosphere {
     }
     Debian: {
       apt::repository { 'mesosphere':
-        url        => "http://repos.mesosphere.io/debian",
+        url        => 'http://repos.mesosphere.io/debian',
         distro     => $::lsbdistcodename,
         repository => 'main',
         key        => 'E56151BF',


### PR DESCRIPTION
Puppet lint will fail when the URL is quoted because there are no variables
inside which need expanding. Double quotes are only really acceptable when
there are. Fix by changing this to single quotes, which also matches other
apt::repository::url references in this repository, and indeed this file.

Fixes the lint tests which fixes the Travis build.