### PR TITLE
Add Cloudflare APT Repo

### DIFF
--- a/manifests/repo/cloudflare.pp
+++ b/manifests/repo/cloudflare.pp
@@ -1,0 +1,12 @@
+# = Class: apt::repo::cloudflare
+#
+class apt::repo::cloudflare {
+
+  apt::repository { 'cloudflare':
+    url        => 'http://pkg.cloudflare.com/',
+    distro     => $::lsbdistcodename,
+    repository => 'main',
+    key_url    => 'https://pkg.cloudflare.com/pubkey.gpg',
+  }
+
+}


### PR DESCRIPTION
Add the Cloudflare apt repo for easy installation of Railgun and other Cloudflare tools. 