### PR TITLE
Install apt-transport-https before apt-get update

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -436,8 +436,11 @@ class apt (
   }
 
   if $apt::bool_force_aptget_update {
-    Package <| title != $apt::package |> {
+    Package <| title != $apt::package and title != 'apt-transport-https' |> {
       require +> Exec['apt_update']
+    }
+    Package <| title == 'apt-transport-https' |> {
+      before +> Exec['apt_update']
     }
   }
 


### PR DESCRIPTION
Because some repo need it (docker, gocd, ...)